### PR TITLE
Modify logging configuration to use dictConfig

### DIFF
--- a/src/logging_config/__init__.py
+++ b/src/logging_config/__init__.py
@@ -1,11 +1,12 @@
 import logging
+import logging.config
 
 import structlog
 
 from structlog_sentry import SentryProcessor
 
 
-def configure_logger():
+def configure_logger(config: dict):
     # Define the shared processors, regardless of whether API is running in prod or dev.
     shared_processors: list[structlog.types.Processor] = [
         structlog.contextvars.merge_contextvars,
@@ -26,37 +27,38 @@ def configure_logger():
         ),
     ]
 
+    config.update(
+        {
+            "version": 1,
+            "formatters": {
+                "json": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.processors.JSONRenderer(),
+                    ],
+                    "foreign_pre_chain": shared_processors,
+                },
+                "development": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processors": [
+                        structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                        structlog.dev.ConsoleRenderer(colors=False),
+                    ],
+                    "foreign_pre_chain": shared_processors,
+                },
+            },
+        }
+    )
+
+    logging.config.dictConfig(config)
+
     structlog.configure(
         processors=shared_processors + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
         logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
-
-    # log_renderer: structlog.types.Processor
-    # # If running in production, render logs with JSON.
-    # if mainframe_settings.production:
-    #     log_renderer = structlog.processors.JSONRenderer()
-    # else:
-    #     # If running in a development environment, pretty print logs
-    #     log_renderer = structlog.dev.ConsoleRenderer()
-
-    # TODO: Once infra for log aggregation is up and running, remove this and go back to
-    # TODO: JSON logging in production.
-    log_renderer = structlog.dev.ConsoleRenderer(colors=False)
-
-    formatter = structlog.stdlib.ProcessorFormatter(
-        foreign_pre_chain=shared_processors,
-        processors=[
-            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-            log_renderer,
-        ],
-    )
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    root_logger = logging.getLogger()
-    root_logger.addHandler(handler)
-    root_logger.setLevel(logging.DEBUG)
 
     # Disable uvicorn's logging
     for _log in ["uvicorn", "uvicorn.error"]:


### PR DESCRIPTION
Closes #11.

Instead of using `fileConfig`, I opted to use `dictConfig` due to the newer API. This configuration itself won't read from a configuration file, it instead accepts a dictionary as an argument to `configure_logger` and leaves reading in a configuration file to the end user.
