### PR TITLE
Fix bug in middleware when it encounters an exception.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dragonfly-logging-config"
-version = "1.1.0"
+version = "1.2.0"
 description = "Shared logging configuration for Dragonfly codebases"
 authors = [{ name = "Vipyr Security", email = "support@vipyrsec.com" }]
 dependencies = [

--- a/src/logging_config/middleware.py
+++ b/src/logging_config/middleware.py
@@ -16,7 +16,7 @@ class LoggingMiddleware:
             await self.app(scope, receive, send)
             return
 
-        info: Message = {"response": None}
+        info: Message = {"response": {}}
 
         async def inner_send(message: Message) -> None:
             if message["type"] == "http.response.start":

--- a/src/logging_config/middleware.py
+++ b/src/logging_config/middleware.py
@@ -16,7 +16,7 @@ class LoggingMiddleware:
             await self.app(scope, receive, send)
             return
 
-        info: Message = {}
+        info: Message = {"response": None}
 
         async def inner_send(message: Message) -> None:
             if message["type"] == "http.response.start":


### PR DESCRIPTION
When the logging middleware was encountering an exception, it was breaking since the `info` variable in the middleware wouldn't have a `response` field. This fixes that.